### PR TITLE
[feat/#26] 장바구니 주문 버튼 구현

### DIFF
--- a/src/components/Cart/OrderBtn/OrderBtn.styled.ts
+++ b/src/components/Cart/OrderBtn/OrderBtn.styled.ts
@@ -1,0 +1,23 @@
+import styled from "@emotion/styled";
+import theme from "@styles/theme";
+
+export const StyledBtn = styled.button`
+  background-color: ${theme.colors.purple50};
+  border-radius: 10px;
+  color: white;
+  ${theme.fonts.body2_b_14};
+  width: 25rem;
+  height: 5.6rem;
+  transition: 
+    background-color 0.3s ease, 
+    color 0.3s ease, 
+    width 0.3s ease, 
+    height 0.3s ease; 
+
+  &:active {
+    background-color: ${theme.colors.purple60};
+    color: ${theme.colors.purple40};
+    width: 23.6rem; 
+    height: 5.2rem;
+  }
+`;

--- a/src/components/Cart/OrderBtn/OrderBtn.tsx
+++ b/src/components/Cart/OrderBtn/OrderBtn.tsx
@@ -1,0 +1,16 @@
+import * as S from "./OrderBtn.styled"
+
+interface OrderBtnProps {
+  totalItems: number;
+  totalPrice: number;
+}
+
+const OrderBtn = ({ totalItems, totalPrice } : OrderBtnProps) => {
+  return (
+    <S.StyledBtn>
+      {`${totalPrice.toLocaleString()}원 (${totalItems}) 주문하기`}
+    </S.StyledBtn>
+  ); 
+};
+
+export default OrderBtn;


### PR DESCRIPTION
<!-- PR 제목은 '[핏,픽스등등/#이슈번호] 작업 내용' 과 같은 형태로 작성해주세요.  -->

### 📑 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #26

<br>

### ✨️ 작업 내용
<!-- 작업 내용을 간략히 설명해주세요 -->
장바구니 주문 버튼을 구현하였습니뎅

<br>

### 🌊 코멘트
<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 자유롭게 남겨주세요! -->
장바구니 페이지에서 장바구니 데이터를 불러오고, 해당 데이터 기반으로 총 금액과 갯수를 계산하여 버튼에 표시하기 위해 `totalItems`, `totalPrice` 를 props로 받습니다 !


<br>

### 📸 구현 결과
<!-- 구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요 (스크린샷, gif, 동영상, 배포링크 등) -->

https://github.com/user-attachments/assets/1a83a92d-58fa-48b8-aef0-4a3e77d58399





<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->
